### PR TITLE
Reintroduce recipeBook crafting

### DIFF
--- a/src/main/java/fi/dy/masa/itemscroller/config/Configs.java
+++ b/src/main/java/fi/dy/masa/itemscroller/config/Configs.java
@@ -35,6 +35,7 @@ public class Configs implements IConfigHandler
         public static final ConfigInteger MASS_CRAFT_INTERVAL                   = new ConfigInteger("massCraftInterval",                    2, 1, 60, "itemscroller.config.generic.comment.massCraftInterval").translatedName("itemscroller.config.generic.name.massCraftInterval");
         public static final ConfigInteger MASS_CRAFT_ITERATIONS                 = new ConfigInteger("massCraftIterations",                  36, 1, 256, "itemscroller.config.generic.comment.massCraftIterations").translatedName("itemscroller.config.generic.name.massCraftIterations");
         public static final ConfigBoolean MASS_CRAFT_SWAPS                      = new ConfigBoolean("massCraftSwapsOnly",                   false, "itemscroller.config.generic.comment.massCraftSwapsOnly").translatedName("itemscroller.config.generic.name.massCraftSwapsOnly");
+        public static final ConfigBoolean MASS_CRAFT_RECIPE_BOOK                = new ConfigBoolean("massCraftUseRecipeBook", false, "itemscroller.config.generic.comment.massCraftUseRecipeBook").translatedName("itemscroller.config.generic.name.massCraftUseRecipeBook");
         public static final ConfigInteger PACKET_RATE_LIMIT                     = new ConfigInteger("packetRateLimit",                      4, 1, 1024, "itemscroller.config.generic.comment.packetRateLimit").translatedName("itemscroller.config.generic.name.packetRateLimit");
         public static final ConfigBoolean SCROLL_CRAFT_STORE_RECIPES_TO_FILE    = new ConfigBoolean("craftingRecipesSaveToFile",            true, "itemscroller.config.generic.comment.craftingRecipesSaveToFile").translatedName("itemscroller.config.generic.name.craftingRecipesSaveToFile");
         public static final ConfigBoolean SCROLL_CRAFT_RECIPE_FILE_GLOBAL       = new ConfigBoolean("craftingRecipesSaveFileIsGlobal",      false, "itemscroller.config.generic.comment.craftingRecipesSaveFileIsGlobal").translatedName("itemscroller.config.generic.name.craftingRecipesSaveFileIsGlobal");
@@ -57,6 +58,7 @@ public class Configs implements IConfigHandler
                 MASS_CRAFT_INTERVAL,
                 MASS_CRAFT_ITERATIONS,
                 MASS_CRAFT_SWAPS,
+                MASS_CRAFT_RECIPE_BOOK,
                 MOD_MAIN_TOGGLE,
                 PACKET_RATE_LIMIT,
                 RATE_LIMIT_CLICK_PACKETS,

--- a/src/main/java/fi/dy/masa/itemscroller/event/KeybindCallbacks.java
+++ b/src/main/java/fi/dy/masa/itemscroller/event/KeybindCallbacks.java
@@ -5,6 +5,8 @@ import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.screen.ingame.CreativeInventoryScreen;
 import net.minecraft.client.gui.screen.ingame.HandledScreen;
 import net.minecraft.inventory.RecipeInputInventory;
+import net.minecraft.item.ItemStack;
+import net.minecraft.network.packet.s2c.play.ScreenHandlerSlotUpdateS2CPacket;
 import net.minecraft.screen.slot.Slot;
 import fi.dy.masa.malilib.config.options.ConfigHotkey;
 import fi.dy.masa.malilib.gui.GuiBase;
@@ -29,6 +31,8 @@ public class KeybindCallbacks implements IHotkeyCallback, IClientTickHandler
     private static final KeybindCallbacks INSTANCE = new KeybindCallbacks();
 
     protected int massCraftTicker;
+
+    private boolean recipeBookClicks = false;
 
     public static KeybindCallbacks getInstance()
     {
@@ -223,9 +227,58 @@ public class KeybindCallbacks implements IHotkeyCallback, IClientTickHandler
                 }
 
                 RecipePattern recipe = RecipeStorage.getInstance().getSelectedRecipe();
+                if (recipe.getVanillaRecipe() == null) {
+                    recipe.lookupVanillaRecipe(mc.world);
+                }
+
                 int limit = Configs.Generic.MASS_CRAFT_ITERATIONS.getIntegerValue();
 
-                if (Configs.Generic.MASS_CRAFT_SWAPS.getBooleanValue())
+                if (Configs.Generic.MASS_CRAFT_RECIPE_BOOK.getBooleanValue() && recipe.getVanillaRecipe() != null)
+                {
+                    InventoryUtils.dontUpdateRecipeBook = true;
+                    for (int i = 0; i < limit; ++i)
+                    {
+                        // todo
+//                        InventoryUtils.tryClearCursor(gui);
+//                        InventoryUtils.setInhibitCraftingOutputUpdate(true);
+                        InventoryUtils.throwAllCraftingResultsToGround(recipe, gui);
+
+                        RecipeInputInventory craftingInv = ((IMixinCraftingResultSlot) outputSlot).itemscroller_getCraftingInventory();
+                        if (!recipe.getVanillaRecipe().matches(craftingInv.createRecipeInput(), mc.world))
+                        {
+                            CraftingHandler.SlotRange range = CraftingHandler.getCraftingGridSlots(gui, outputSlot);
+                            final int invSlots = gui.getScreenHandler().slots.size();
+                            final int rangeSlots = range.getSlotCount();
+
+                            for (int j = 0, slotNum = range.getFirst(); j < rangeSlots && slotNum < invSlots; j++, slotNum++)
+                            {
+                                InventoryUtils.shiftClickSlot(gui, slotNum);
+
+                                Slot slotTmp = gui.getScreenHandler().getSlot(slotNum);
+                                ItemStack stack = slotTmp.getStack();
+                                if (!stack.isEmpty())
+                                {
+                                    InventoryUtils.dropStack(gui, slotNum);
+                                }
+                            }
+                        }
+
+                        mc.interactionManager.clickRecipe(gui.getScreenHandler().syncId, recipe.getVanillaRecipeEntry(), true);
+//                        InventoryUtils.setInhibitCraftingOutputUpdate(false);
+//                        InventoryUtils.updateCraftingOutputSlot(outputSlot);
+
+                        craftingInv = ((IMixinCraftingResultSlot) outputSlot).itemscroller_getCraftingInventory();
+                        if (recipe.getVanillaRecipe().matches(craftingInv.createRecipeInput(), mc.world))
+                        {
+                            break;
+                        }
+
+                        InventoryUtils.shiftClickSlot(gui, outputSlot.id);
+                        recipeBookClicks = true;
+                    }
+                    InventoryUtils.dontUpdateRecipeBook = false;
+                }
+                else if (Configs.Generic.MASS_CRAFT_SWAPS.getBooleanValue())
                 {
                     for (int i = 0; i < limit; ++i)
                     {
@@ -300,5 +353,10 @@ public class KeybindCallbacks implements IHotkeyCallback, IClientTickHandler
                 return true;
             });
         }
+    }
+
+    public void onPacket(ScreenHandlerSlotUpdateS2CPacket packet)
+    {
+        var mc = MinecraftClient.getInstance();
     }
 }

--- a/src/main/java/fi/dy/masa/itemscroller/event/KeybindCallbacks.java
+++ b/src/main/java/fi/dy/masa/itemscroller/event/KeybindCallbacks.java
@@ -235,7 +235,7 @@ public class KeybindCallbacks implements IHotkeyCallback, IClientTickHandler
 
                 if (Configs.Generic.MASS_CRAFT_RECIPE_BOOK.getBooleanValue() && recipe.lookupVanillaRecipe(mc.world) != null)
                 {
-                    InventoryUtils.dontUpdateRecipeBook = 10;
+                    InventoryUtils.dontUpdateRecipeBook = 2;
                     for (int i = 0; i < limit; ++i)
                     {
                         // todo

--- a/src/main/java/fi/dy/masa/itemscroller/event/KeybindCallbacks.java
+++ b/src/main/java/fi/dy/masa/itemscroller/event/KeybindCallbacks.java
@@ -194,6 +194,9 @@ public class KeybindCallbacks implements IHotkeyCallback, IClientTickHandler
     @Override
     public void onClientTick(MinecraftClient mc)
     {
+        if (InventoryUtils.dontUpdateRecipeBook > 0) {
+            --InventoryUtils.dontUpdateRecipeBook;
+        }
         if (this.functionalityEnabled() == false || mc.player == null)
         {
             return;
@@ -232,7 +235,7 @@ public class KeybindCallbacks implements IHotkeyCallback, IClientTickHandler
 
                 if (Configs.Generic.MASS_CRAFT_RECIPE_BOOK.getBooleanValue() && recipe.lookupVanillaRecipe(mc.world) != null)
                 {
-                    InventoryUtils.dontUpdateRecipeBook = true;
+                    InventoryUtils.dontUpdateRecipeBook = 10;
                     for (int i = 0; i < limit; ++i)
                     {
                         // todo
@@ -273,7 +276,6 @@ public class KeybindCallbacks implements IHotkeyCallback, IClientTickHandler
                         InventoryUtils.shiftClickSlot(gui, outputSlot.id);
                         recipeBookClicks = true;
                     }
-                    InventoryUtils.dontUpdateRecipeBook = false;
                 }
                 else if (Configs.Generic.MASS_CRAFT_SWAPS.getBooleanValue())
                 {

--- a/src/main/java/fi/dy/masa/itemscroller/event/KeybindCallbacks.java
+++ b/src/main/java/fi/dy/masa/itemscroller/event/KeybindCallbacks.java
@@ -227,13 +227,10 @@ public class KeybindCallbacks implements IHotkeyCallback, IClientTickHandler
                 }
 
                 RecipePattern recipe = RecipeStorage.getInstance().getSelectedRecipe();
-                if (recipe.getVanillaRecipe() == null) {
-                    recipe.lookupVanillaRecipe(mc.world);
-                }
 
                 int limit = Configs.Generic.MASS_CRAFT_ITERATIONS.getIntegerValue();
 
-                if (Configs.Generic.MASS_CRAFT_RECIPE_BOOK.getBooleanValue() && recipe.getVanillaRecipe() != null)
+                if (Configs.Generic.MASS_CRAFT_RECIPE_BOOK.getBooleanValue() && recipe.lookupVanillaRecipe(mc.world) != null)
                 {
                     InventoryUtils.dontUpdateRecipeBook = true;
                     for (int i = 0; i < limit; ++i)

--- a/src/main/java/fi/dy/masa/itemscroller/mixin/MixinClientPlayNetworkHandler.java
+++ b/src/main/java/fi/dy/masa/itemscroller/mixin/MixinClientPlayNetworkHandler.java
@@ -1,7 +1,12 @@
 package fi.dy.masa.itemscroller.mixin;
 
+import fi.dy.masa.itemscroller.config.Configs;
+import fi.dy.masa.itemscroller.config.Hotkeys;
+import fi.dy.masa.itemscroller.event.KeybindCallbacks;
 import fi.dy.masa.itemscroller.util.InventoryUtils;
 import net.minecraft.client.network.ClientPlayNetworkHandler;
+import net.minecraft.network.packet.s2c.play.CraftFailedResponseS2CPacket;
+import net.minecraft.network.packet.s2c.play.ScreenHandlerSlotUpdateS2CPacket;
 import net.minecraft.network.packet.s2c.play.InventoryS2CPacket;
 import net.minecraft.network.packet.s2c.play.ScreenHandlerSlotUpdateS2CPacket;
 import net.minecraft.network.packet.s2c.play.StatisticsS2CPacket;
@@ -20,6 +25,26 @@ public class MixinClientPlayNetworkHandler
         {
             ci.cancel();
         }
+    }
+
+    @Inject(method = "onScreenHandlerSlotUpdate", at = @At("RETURN"))
+    private void onScreenHandlerSlotUpdate(ScreenHandlerSlotUpdateS2CPacket packet, CallbackInfo ci)
+    {
+        KeybindCallbacks.getInstance().onPacket(packet);
+    }
+
+    @Inject(
+            method = "onCraftFailedResponse",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/network/NetworkThreadUtils;forceMainThread(Lnet/minecraft/network/packet/Packet;Lnet/minecraft/network/listener/PacketListener;Lnet/minecraft/util/thread/ThreadExecutor;)V",
+                    shift = At.Shift.AFTER
+            ),
+            cancellable = true
+    )
+    private void onCraftFailedResponse(CraftFailedResponseS2CPacket packet, CallbackInfo ci)
+    {
+        // todo
     }
 
     @Inject(
@@ -48,7 +73,7 @@ public class MixinClientPlayNetworkHandler
             ),
             cancellable = true
     )
-    private void onScreenHandlerSlotUpdate(ScreenHandlerSlotUpdateS2CPacket packet, CallbackInfo ci)
+    private void onScreenHandlerSlotUpdateInvokeMainThread(ScreenHandlerSlotUpdateS2CPacket packet, CallbackInfo ci)
     {
         if (InventoryUtils.bufferInvUpdates)
         {

--- a/src/main/java/fi/dy/masa/itemscroller/mixin/MixinRecipeBookWidget.java
+++ b/src/main/java/fi/dy/masa/itemscroller/mixin/MixinRecipeBookWidget.java
@@ -28,4 +28,14 @@ public class MixinRecipeBookWidget
             ci.cancel();
         }
     }
+
+    @Inject(method = "drawGhostSlots", at = @At("HEAD"), cancellable = true)
+    private void onDrawGhostSlots(CallbackInfo ci)
+    {
+        if (InventoryUtils.dontUpdateRecipeBook > 0)
+        {
+            ci.cancel();
+        }
+    }
+
 }

--- a/src/main/java/fi/dy/masa/itemscroller/mixin/MixinRecipeBookWidget.java
+++ b/src/main/java/fi/dy/masa/itemscroller/mixin/MixinRecipeBookWidget.java
@@ -14,7 +14,16 @@ public class MixinRecipeBookWidget
     @Inject(method = "slotClicked", at = @At("HEAD"), cancellable = true)
     private void onSlotClicked(Slot slot, CallbackInfo ci)
     {
-        if (InventoryUtils.dontUpdateRecipeBook)
+        if (InventoryUtils.dontUpdateRecipeBook > 0)
+        {
+            ci.cancel();
+        }
+    }
+
+    @Inject(method = "update", at = @At("HEAD"), cancellable = true)
+    private void onUpdate(CallbackInfo ci)
+    {
+        if (InventoryUtils.dontUpdateRecipeBook > 0)
         {
             ci.cancel();
         }

--- a/src/main/java/fi/dy/masa/itemscroller/mixin/MixinRecipeBookWidget.java
+++ b/src/main/java/fi/dy/masa/itemscroller/mixin/MixinRecipeBookWidget.java
@@ -1,16 +1,24 @@
 package fi.dy.masa.itemscroller.mixin;
 
 import fi.dy.masa.itemscroller.util.InventoryUtils;
+import net.minecraft.client.gui.screen.recipebook.RecipeBookGhostSlots;
 import net.minecraft.client.gui.screen.recipebook.RecipeBookWidget;
+import net.minecraft.recipe.RecipeEntry;
 import net.minecraft.screen.slot.Slot;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+import java.util.List;
+
 @Mixin(RecipeBookWidget.class)
 public class MixinRecipeBookWidget
 {
+    @Shadow @Final protected RecipeBookGhostSlots ghostSlots;
+
     @Inject(method = "slotClicked", at = @At("HEAD"), cancellable = true)
     private void onSlotClicked(Slot slot, CallbackInfo ci)
     {
@@ -29,13 +37,15 @@ public class MixinRecipeBookWidget
         }
     }
 
-    @Inject(method = "drawGhostSlots", at = @At("HEAD"), cancellable = true)
-    private void onDrawGhostSlots(CallbackInfo ci)
-    {
-        if (InventoryUtils.dontUpdateRecipeBook > 0)
-        {
+    // Seems to be (intended) bug from Mojang
+    @Inject(
+            method = "showGhostRecipe",
+            at = @At("HEAD"),
+            cancellable = true
+    )
+    private void onShowGhostRecipe(RecipeEntry<?> recipe, List<Slot> slots, CallbackInfo ci) {
+        if (this.ghostSlots.getRecipe() == recipe) {
             ci.cancel();
         }
     }
-
 }

--- a/src/main/java/fi/dy/masa/itemscroller/mixin/MixinRecipeBookWidget.java
+++ b/src/main/java/fi/dy/masa/itemscroller/mixin/MixinRecipeBookWidget.java
@@ -1,9 +1,22 @@
 package fi.dy.masa.itemscroller.mixin;
 
+import fi.dy.masa.itemscroller.util.InventoryUtils;
 import net.minecraft.client.gui.screen.recipebook.RecipeBookWidget;
+import net.minecraft.screen.slot.Slot;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(RecipeBookWidget.class)
 public class MixinRecipeBookWidget
 {
+    @Inject(method = "slotClicked", at = @At("HEAD"), cancellable = true)
+    private void onSlotClicked(Slot slot, CallbackInfo ci)
+    {
+        if (InventoryUtils.dontUpdateRecipeBook)
+        {
+            ci.cancel();
+        }
+    }
 }

--- a/src/main/java/fi/dy/masa/itemscroller/recipes/RecipePattern.java
+++ b/src/main/java/fi/dy/masa/itemscroller/recipes/RecipePattern.java
@@ -55,7 +55,7 @@ public class RecipePattern
         this.clearRecipe();
     }
 
-    private void lookupVanillaRecipe(World world) {
+    public void lookupVanillaRecipe(World world) {
         this.vanillaRecipe = null;
         var mc = MinecraftClient.getInstance();
         int recipeSize;
@@ -152,7 +152,6 @@ public class RecipePattern
             }
 
             this.result = ItemStack.fromNbtOrEmpty(registryManager, nbt.getCompound("Result"));
-            this.lookupVanillaRecipe(MinecraftClient.getInstance().world);
         }
     }
 

--- a/src/main/java/fi/dy/masa/itemscroller/recipes/RecipePattern.java
+++ b/src/main/java/fi/dy/masa/itemscroller/recipes/RecipePattern.java
@@ -55,7 +55,9 @@ public class RecipePattern
         this.clearRecipe();
     }
 
-    public void lookupVanillaRecipe(World world) {
+    @Nullable
+    public <T extends RecipeInput> Recipe<T> lookupVanillaRecipe(World world) {
+        //Assume all recipes here are of type CraftingRecipe
         this.vanillaRecipe = null;
         var mc = MinecraftClient.getInstance();
         int recipeSize;
@@ -69,7 +71,7 @@ public class RecipePattern
         }
         else
         {
-            return;
+            return null;
         }
 
         for (RecipeEntry<CraftingRecipe> match : mc.world.getRecipeManager().getAllMatches(RecipeType.CRAFTING, CraftingRecipeInput.create(recipeSize, recipeSize, Arrays.asList(recipe)), world))
@@ -77,9 +79,10 @@ public class RecipePattern
             if (InventoryUtils.areStacksEqual(result, match.value().getResult(world.getRegistryManager())))
             {
                 this.vanillaRecipe = match;
-                return;
+                return (Recipe<T>) match.value();
             }
         }
+        return null;
     }
 
     public void storeCraftingRecipe(Slot slot, HandledScreen<? extends ScreenHandler> gui, boolean clearIfEmpty)
@@ -224,7 +227,7 @@ public class RecipePattern
     @Nullable
     public <T extends RecipeInput> Recipe<T> getVanillaRecipe()
     {
-        if (vanillaRecipe == null)
+        if (recipe == null)
         {
             return null;
         }

--- a/src/main/java/fi/dy/masa/itemscroller/util/InventoryUtils.java
+++ b/src/main/java/fi/dy/masa/itemscroller/util/InventoryUtils.java
@@ -64,6 +64,7 @@ public class InventoryUtils
 {
     private static final Set<Integer> DRAGGED_SLOTS = new HashSet<>();
     private static final int SERVER_SYNC_MAGIC = 45510;
+    public static boolean dontUpdateRecipeBook;
 
     private static WeakReference<Slot> sourceSlotCandidate = null;
     private static WeakReference<Slot> sourceSlot = null;

--- a/src/main/java/fi/dy/masa/itemscroller/util/InventoryUtils.java
+++ b/src/main/java/fi/dy/masa/itemscroller/util/InventoryUtils.java
@@ -64,7 +64,7 @@ public class InventoryUtils
 {
     private static final Set<Integer> DRAGGED_SLOTS = new HashSet<>();
     private static final int SERVER_SYNC_MAGIC = 45510;
-    public static boolean dontUpdateRecipeBook;
+    public static int dontUpdateRecipeBook;
 
     private static WeakReference<Slot> sourceSlotCandidate = null;
     private static WeakReference<Slot> sourceSlot = null;


### PR DESCRIPTION
Fix the code from @zly2006 (code originally in #4 , and idea from Andrew's craftfix fork) which is not actually using recipe books for crafting (the vanilla recipe manager is not ready when just after connecting to the client, it sync the recipe information after receiving packets). 

This crafting method is much stable than swapOnly and the old method, it make much fewer mistakes in crafting.