### PR TITLE
Fixed sorting modded items with a null check

### DIFF
--- a/src/main/java/fi/dy/masa/itemscroller/util/SortingCategory.java
+++ b/src/main/java/fi/dy/masa/itemscroller/util/SortingCategory.java
@@ -91,7 +91,11 @@ public class SortingCategory implements IConfigLockedListType
 
         if (id != null)
         {
-            return Entry.fromString(id.getPath());
+            Entry entry = Entry.fromString(id.getPath()); 
+            if (entry != null)
+            {
+                return entry;
+            }
         }
 
         return Entry.OTHER;


### PR DESCRIPTION
Fixed a bug that would sorting fail with mods that added new items in a new creative tab, by adding a null check.

<img width="812" height="58" alt="Error message" src="https://github.com/user-attachments/assets/fe113611-31a7-4069-8637-5f7b68fe96c2" />

| Before | → | After |
|--------|---|-------|
| ![Before](https://github.com/user-attachments/assets/1a95588f-ae36-4b41-9a2d-fdccc4f72ffe) | ➜ | ![After](https://github.com/user-attachments/assets/4ea629f8-91be-4465-95bb-e140599d5d0a) |

Example with items from [Decorations Not Found](https://modrinth.com/mod/deco-not-found) and [More furnaces (Polymer)](https://modrinth.com/mod/morefurnaces), as they don't put their items into vanilla categories.