### PR TITLE
Fix mass-craft leaving inventory updates suppressed (freezes item pickup)

### DIFF
--- a/src/main/java/fi/dy/masa/itemscroller/event/KeybindCallbacks.java
+++ b/src/main/java/fi/dy/masa/itemscroller/event/KeybindCallbacks.java
@@ -224,56 +224,67 @@ public class KeybindCallbacks implements IHotkeyCallback, IClientTickHandler
             }
 
             InventoryUtils.bufferInvUpdates = true;
-            final Slot outputSlot = CraftingHandler.getFirstCraftingOutputSlotForGui(gui);
 
-            if (outputSlot != null)
+            try
             {
-                final CraftingHandler.SlotRange range = CraftingHandler.getCraftingGridSlots(gui, outputSlot);
-                final RecipePattern recipe = RecipeStorage.getInstance().getSelectedRecipe();
-                final int limit = Configs.Generic.MASS_CRAFT_ITERATIONS.getIntegerValue();
+                final Slot outputSlot = CraftingHandler.getFirstCraftingOutputSlotForGui(gui);
 
-                if (!recipe.getResult().isEmpty() && range != null)
+                if (outputSlot != null)
                 {
-                    // Too small of a grid; Cancel.
-                    if (range.getSlotCount() < recipe.countRecipeItems())
-                    {
-                        return;
-                    }
+                    final CraftingHandler.SlotRange range = CraftingHandler.getCraftingGridSlots(gui, outputSlot);
+                    final RecipePattern recipe = RecipeStorage.getInstance().getSelectedRecipe();
+                    final int limit = Configs.Generic.MASS_CRAFT_ITERATIONS.getIntegerValue();
 
-                    if (Configs.Generic.RATE_LIMIT_CLICK_PACKETS.getBooleanValue())
+                    if (!recipe.getResult().isEmpty() && range != null)
                     {
-                        ClickPacketBuffer.setShouldBufferClickPackets(true);
-                    }
-
-                    if (Configs.Generic.MASS_CRAFT_RECIPE_BOOK.getBooleanValue() && recipe.getNetworkRecipeId() != null)
-                    {
-                        this.onTickRecipeBook(mc, gui, range, outputSlot, recipe, limit);
-
-                        if (this.badRecipeClicks < 0L)
+                        // Too small of a grid; cancel this tick. The finally block still releases
+                        // the inventory-update buffer, so item pickup never freezes.
+                        if (range.getSlotCount() < recipe.countRecipeItems())
                         {
-                            this.badRecipeClicks = 0L;
+                            return;
+                        }
+
+                        if (Configs.Generic.RATE_LIMIT_CLICK_PACKETS.getBooleanValue())
+                        {
+                            ClickPacketBuffer.setShouldBufferClickPackets(true);
+                        }
+
+                        if (Configs.Generic.MASS_CRAFT_RECIPE_BOOK.getBooleanValue() && recipe.getNetworkRecipeId() != null)
+                        {
+                            this.onTickRecipeBook(mc, gui, range, outputSlot, recipe, limit);
+
+                            if (this.badRecipeClicks < 0L)
+                            {
+                                this.badRecipeClicks = 0L;
+                            }
+                        }
+                        else if (Configs.Generic.MASS_CRAFT_SWAPS.getBooleanValue())
+                        {
+                            this.onTickSwapsOnly(mc, gui, range, outputSlot, recipe, limit);
+                        }
+                        else
+                        {
+                            this.onTickFallback(mc, gui, range, outputSlot, recipe, limit);
                         }
                     }
-                    else if (Configs.Generic.MASS_CRAFT_SWAPS.getBooleanValue())
-                    {
-                        this.onTickSwapsOnly(mc, gui, range, outputSlot, recipe, limit);
-                    }
-                    else
-                    {
-                        this.onTickFallback(mc, gui, range, outputSlot, recipe, limit);
-                    }
-
-                    ClickPacketBuffer.setShouldBufferClickPackets(false);
                 }
-            }
 
-            this.massCraftTicker = 0;
-            InventoryUtils.bufferInvUpdates = false;
-            InventoryUtils.invUpdatesBuffer.removeIf(packet ->
-                                                     {
-                                                         packet.handle(mc.player.connection);
-                                                         return true;
-                                                     });
+                this.massCraftTicker = 0;
+            }
+            finally
+            {
+                // Always release the click-packet and inventory-update buffers and flush any
+                // queued inventory packets — even on the early return above or an exception.
+                // Leaving bufferInvUpdates true makes the client stop applying inventory updates,
+                // which freezes item pickup entirely.
+                ClickPacketBuffer.setShouldBufferClickPackets(false);
+                InventoryUtils.bufferInvUpdates = false;
+                InventoryUtils.invUpdatesBuffer.removeIf(packet ->
+                                                         {
+                                                             packet.handle(mc.player.connection);
+                                                             return true;
+                                                         });
+            }
         }
         else
         {


### PR DESCRIPTION
## Summary

Fixes a bug where **item pickup freezes** after mass-crafting: the client stops registering inventory changes (picked-up items never appear) until the game is restarted.

## Root cause

`KeybindCallbacks.onClientTickMassCraftImpl` sets `InventoryUtils.bufferInvUpdates = true` so that `MixinClientPlayNetworkHandler` buffers incoming inventory packets during a mass-craft tick, then resets the flag and flushes the buffer at the end of the method.

The problem is the **"too small of a grid" early `return`**:

```java
// Too small of a grid; Cancel.
if (range.getSlotCount() < recipe.countRecipeItems())
{
    return;   // <-- returns before bufferInvUpdates is reset / buffer flushed
}
```

When this path is taken, `bufferInvUpdates` stays `true` permanently. From then on every `SetSlot` / container-content packet is buffered and never applied, so the client's inventory is effectively frozen and item pickups don't show up.

## Repro

1. Toggle mass-craft hold on.
2. Select a 3×3 recipe (e.g. piston).
3. Open the 2×2 player-inventory crafting grid — `range.getSlotCount() < recipe.countRecipeItems()` triggers the early return.
4. Pickups are now frozen until a client restart.

## Fix

Wrap the buffered region in `try { … } finally { … }` so `bufferInvUpdates` and the click-packet buffer are **always** released and the queued inventory packets flushed — on the early return, or on any exception thrown from the crafting paths. Behaviour is otherwise unchanged.

## Verification

Reasoning-verified and compiles clean against `26.2` (JDK 25 / fabric-loom). In-game confirmation of the freeze-repro fix is in progress; happy to update once fully soak-tested.

---

## Separate known issue (no code here — just flagging for awareness)

While investigating the above we also hit **mass-craft occasionally ejecting raw ingredients onto the ground** (bad for auto-crafters, which get clogged with stray ingredient groups). It reproduces across paths, e.g.:

- `InventoryUtils.clearCraftingGridOfItems` / `setCraftingGridContentsUsingSwaps` / `tryClearCursor` drop items to the ground when a shift-click back to the inventory fails (full inventory).
- `throwAllNonRecipeItemsToGround` drops grid stacks that don't match the recipe **by position**, but the recipe-book/swaps auto-fill doesn't always place ingredients in the stored `RecipePattern` positions, so valid ingredients get flagged as non-recipe.
- The recipe-book path's `handlePlaceRecipe` triggers vanilla `ServerPlaceRecipe.clearGrid()` → `Inventory.placeItemBackInInventory` → `Player.drop()` server-side when the inventory is full (unavoidable client-side).

Not fixing that here to keep this PR focused, but flagging it in case it's useful. Happy to open a separate issue/PR (an opt-in "don't drop non-recipe items" config that leaves ingredients in place and pauses instead of ejecting worked well in testing).
