### PR TITLE
Persist villager scroll positions when closing trades

### DIFF
--- a/src/main/java/fi/dy/masa/itemscroller/mixin/screen/MixinHandledScreen.java
+++ b/src/main/java/fi/dy/masa/itemscroller/mixin/screen/MixinHandledScreen.java
@@ -2,19 +2,31 @@ package fi.dy.masa.itemscroller.mixin.screen;
 
 import java.util.List;
 import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
+import net.minecraft.client.gui.screens.inventory.MerchantScreen;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.BundleItem;
 import net.minecraft.world.item.ItemStack;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import fi.dy.masa.itemscroller.util.InventoryUtils;
+import fi.dy.masa.itemscroller.villager.VillagerDataStorage;
 
 @Mixin(AbstractContainerScreen.class)
 public class MixinHandledScreen
 {
+	@Inject(method = "removed", at = @At("HEAD"))
+	private void itemscroller_saveVillagerDataOnClose(CallbackInfo ci)
+	{
+		if ((Object) this instanceof MerchantScreen)
+		{
+			VillagerDataStorage.getInstance().writeToDisk();
+		}
+	}
+
 	@Inject(method = "getTooltipFromContainerItem(Lnet/minecraft/world/item/ItemStack;)Ljava/util/List;", at = @At("HEAD"))
 	private void itemscroller_ignore_bundleTooltipsForScrolling(ItemStack itemStack, CallbackInfoReturnable<List<Component>> cir)
 	{


### PR DESCRIPTION
Villager scroll positions currently rely on the world unload callback to be written to disk.

Save dirty villager data when the merchant screen closes so positions survive disconnects and game restarts.

This also reduces sensitivity to mods that hook client chunk or world teardown.